### PR TITLE
Improve page type specification logic.

### DIFF
--- a/Reloader/Xamarin.Forms.HotReload.Reloader/HotReloader.cs
+++ b/Reloader/Xamarin.Forms.HotReload.Reloader/HotReloader.cs
@@ -42,6 +42,11 @@ namespace Xamarin.Forms.HotReload
 
         public void InitializeElement<TXaml>(TXaml element) where TXaml : Element
         {
+            InitializeElement(element, typeof(TXaml));
+        }
+
+        public void InitializeElement(Element element, Type elementType)
+        {
             if(!IsRunning)
             {
                 return;
@@ -49,8 +54,7 @@ namespace Xamarin.Forms.HotReload
 
             element.PropertyChanged += OnElementPropertyChanged;
 
-            var classType = typeof(TXaml);
-            var className = RetriveClassName(classType);
+            var className = RetriveClassName(elementType);
             if(!_fileMapping.TryGetValue(className, out ReloadItem item))
             {
                 item = new ReloadItem();
@@ -61,7 +65,7 @@ namespace Xamarin.Forms.HotReload
 
             if (string.IsNullOrWhiteSpace(item.Xaml))
             {
-                element.LoadFromXaml(classType);
+                element.LoadFromXaml(elementType);
                 _fileMapping[className] = item;
                 return;
             }


### PR DESCRIPTION
# Improve page type specification logic.

Modify the Element type specification logic and API so that you can write code more easily when setting up the HotReloader for each Xamarin.Forms Element.

## Use case
As described in [README.md](https://github.com/AndreiMisiukevich/HotReload/blob/a3880c5c4b44c7a7a3ce23feb539682ae0585418/README.md), ALL XAML partial classes (ContentPage, ViewCell etc.) MUST be set up like:


```csharp
#if DEBUG
using Xamarin.Forms.HotReload.Reloader;
#endif

using System.Windows.Input;

namespace Xamarin.Forms.HotReload.Sample
{
    public partial class MainPage : ContentPage
    {
        public MainPage()
        {
#if DEBUG
            this.InitializeElement();
#else
            InitializeComponent();
#endif
        }
    }
}
```

However, I did not want to write the HotReloader setup code-`InitializeComponent`-repeatedly 
([DRY-Don't Repeat Yourself](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)). Instead, I wanted to use the Page Factory to generate the Page, and have the HotRenderer setup code run alongside. This will bring the HotReloader related code into one place. In other words, all of the Page classes are isolated from HotReloader, so you can keep your code clean! Therefore, the range of influence of HotReloader related code addition/deletion task becomes smaller, and anxiety felt in the task is reduced. Obviously, difficulty of the task also becomes easier. Let's look at a concrete use case with following two source code.

- How to apply HotReloader setup code to PageFactory.
    ```csharp
    public class PageFactory : IPageFactory
    {
        
        // ...

        public TPage Create<TPage>() where TPage : Xamarin.Forms.Page
        {
            TPage page = _container.Resolve<TPage>();
    #if UseHotReload
            Xamarin.Forms.HotReload.HotReloader.Current.InitializeElement<TPage>(page);
    #endif
            return page;
        }

        // ...

    }
    ```

- How to customize the [PageNavigationService](https://github.com/PrismLibrary/Prism/blob/930e2b062eba7dcf38fc4aed603376ff06f15f44/Source/Xamarin/Prism.Forms/Navigation/PageNavigationService.cs) when using the [Prism Framework](https://github.com/PrismLibrary/Prism). If you customize only the Prism Framework's INavigationService as follows, HotReloader is automatically set to all pages.

    ```csharp
    public class PageFactoryNavigationService : PageNavigationService
    {

        // ...
        
        protected override Page CreatePage(string segmentName)
        {
            Page page = base.CreatePage(segmentName);
    #if UseHotReload
            // Existing API
            // Xamarin.Forms.HotReload.HotReloader.Current.InitializeElement<Page>(page);

            // New API
            Xamarin.Forms.HotReload.HotReloader.Current.InitializeElement(page, page.GetType());
    #endif
            return page;
        }
        
        // ...
    
    }
    ```

## Problems with existing code

When setting up the HotReloader in the second use case, the problem occurs if you call the existing `InitializeElement` method as follows:

```csharp
// Existing API
Xamarin.Forms.HotReload.HotReloader.Current.InitializeElement<Page>(page);
```
In this case, the TXaml Generic Type is of type Xamarin.Forms.Page, the problem is that the `InitializeElement <TXaml> (TXaml element)` method internally uses **TXaml** to infer the type of the page instance.

## Solution

Modify the method so that the caller can specify the type when calling the `InitializeElement` method. At the same time, existing APIs are useful, so consider supporting it as they are. As a result, the HotReloader initialization API consumer will be able to use following two APIs:

```csharp
// Existing API
// void InitializeElement<TXaml>(TXaml element) where TXaml : Element
Xamarin.Forms.HotReload.HotReloader.Current.InitializeElement(page);

// New API
// void InitializeElement(Element element, Type elementType)
Xamarin.Forms.HotReload.HotReloader.Current.InitializeElement(page, page.GetType());
```

https://github.com/AndreiMisiukevich/HotReload/blob/a4b43869a96391d32d8fdf53de0971cd48ab975f/Reloader/Xamarin.Forms.HotReload.Reloader/HotReloader.cs#L43-L74

## Obsolete solution

Modify the existing `InitializeElement` method to use the type of the element instance instead of using the TXaml generic type. To do this, modify line 52 in the following code to `var classType = element.GetType ();`.

https://github.com/AndreiMisiukevich/HotReload/blob/a3880c5c4b44c7a7a3ce23feb539682ae0585418/Reloader/Xamarin.Forms.HotReload.Reloader/HotReloader.cs#L43-L70

The reason for discarding this solution is that we can no longer support the use cases provided by the exiting API approach. It is useful to be able API consumer to specify the type that is appropriate for the element that is passed in as argument, so you must support the existing use case.