### PR TITLE
Fix some observer.exe bugs

### DIFF
--- a/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
+++ b/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
@@ -92,12 +92,6 @@ namespace Xamarin.Forms.HotReload.Observer
         
         private static void OnFileChanged(object source, FileSystemEventArgs e)
         {
-            string fullPath = e.FullPath;
-            if (Regex.IsMatch(fullPath, "(/|^)((obj)|(bin))/"))
-            {
-                return;
-            }
-
             var now = DateTime.Now;
             lock (_locker)
             {
@@ -108,7 +102,7 @@ namespace Xamarin.Forms.HotReload.Observer
                 _lastChangeTime = now;
             }
 
-            var filePath = fullPath.Replace("/.#", "/");
+            var filePath = e.FullPath.Replace("/.#", "/");
             Console.WriteLine($"CHANGED {now}: {filePath}");
             SendFile(filePath);
         }

--- a/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
+++ b/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
@@ -92,8 +92,8 @@ namespace Xamarin.Forms.HotReload.Observer
         
         private static void OnFileChanged(object source, FileSystemEventArgs e)
         {
-            string fullpath = e.FullPath;
-            if (Regex.IsMatch(fullpath, "(/|^)((obj)|(bin))/"))
+            string fullPath = e.FullPath;
+            if (Regex.IsMatch(fullPath, "(/|^)((obj)|(bin))/"))
             {
                 return;
             }
@@ -108,7 +108,7 @@ namespace Xamarin.Forms.HotReload.Observer
                 _lastChangeTime = now;
             }
 
-            var filePath = fullpath.Replace("/.#", "/");
+            var filePath = fullPath.Replace("/.#", "/");
             Console.WriteLine($"CHANGED {now}: {filePath}");
             SendFile(filePath);
         }

--- a/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
+++ b/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
@@ -63,7 +63,7 @@ namespace Xamarin.Forms.HotReload.Observer
                 NotifyFilter = NotifyFilters.LastWrite,
                 Filter = "*.xaml",
                 EnableRaisingEvents = true,
-                IncludeSubdirectories = true,
+                IncludeSubdirectories = true
             };
 
             _client = new HttpClient

--- a/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
+++ b/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
@@ -73,6 +73,7 @@ namespace Xamarin.Forms.HotReload.Observer
 
             observer.Changed += OnFileChanged;
             observer.Created += OnFileChanged;
+            observer.Renamed += OnFileChanged;
             do
             {
                 Console.WriteLine("\nPRESS \'ESC\' TO STOP.");
@@ -80,6 +81,7 @@ namespace Xamarin.Forms.HotReload.Observer
 
             observer.Changed -= OnFileChanged;
             observer.Created -= OnFileChanged;
+            observer.Renamed -= OnFileChanged;
         }
 
         private static string RetrieveCommandLineArgument(string key, string defaultValue, string[] args)


### PR DESCRIPTION
### Fixed bugs
- [x] observer.exe should observe xaml files in subdirectories.
- [x] observer.exe should observe xaml file renamed event.