### PR TITLE
Detecting changes on Windows machines

### DIFF
--- a/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
+++ b/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Forms.HotReload.Observer
             var observer = new FileSystemWatcher
             {
                 Path = path,
-                NotifyFilter = NotifyFilters.LastWrite,
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Attributes | NotifyFilters.Size | NotifyFilters.CreationTime,          
                 Filter = "*.xaml",
                 EnableRaisingEvents = true,
                 IncludeSubdirectories = true
@@ -70,6 +70,7 @@ namespace Xamarin.Forms.HotReload.Observer
                 BaseAddress = new Uri(url)
             };
 
+           observer.Deleted += OnFileChanged;
             observer.Changed += OnFileChanged;
             observer.Created += OnFileChanged;
             observer.Renamed += OnFileChanged;
@@ -78,6 +79,7 @@ namespace Xamarin.Forms.HotReload.Observer
                 Console.WriteLine("\nPRESS \'ESC\' TO STOP.");
             } while (Console.ReadKey().Key != ConsoleKey.Escape);
 
+            observer.Deleted -= OnFileChanged;
             observer.Changed -= OnFileChanged;
             observer.Created -= OnFileChanged;
             observer.Renamed -= OnFileChanged;

--- a/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
+++ b/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
@@ -70,7 +70,6 @@ namespace Xamarin.Forms.HotReload.Observer
                 BaseAddress = new Uri(url)
             };
 
-           observer.Deleted += OnFileChanged;
             observer.Changed += OnFileChanged;
             observer.Created += OnFileChanged;
             observer.Renamed += OnFileChanged;
@@ -79,7 +78,6 @@ namespace Xamarin.Forms.HotReload.Observer
                 Console.WriteLine("\nPRESS \'ESC\' TO STOP.");
             } while (Console.ReadKey().Key != ConsoleKey.Escape);
 
-            observer.Deleted -= OnFileChanged;
             observer.Changed -= OnFileChanged;
             observer.Created -= OnFileChanged;
             observer.Renamed -= OnFileChanged;


### PR DESCRIPTION
NotifyFilters should be extended and also Deleted event handler should be added. because when you change a file over VS, it creates copy and deletes original according to this post https://stackoverflow.com/questions/680698/why-doesnt-filesystemwatcher-detect-changes-from-visual-studio