### PR TITLE
implemented Source Link to step into the code while debugging

### DIFF
--- a/Reloader/Xamarin.Forms.HotReload.Reloader/Xamarin.Forms.HotReload.Reloader.csproj
+++ b/Reloader/Xamarin.Forms.HotReload.Reloader/Xamarin.Forms.HotReload.Reloader.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.6.0.220655" />
+    <PackageReference Include="Xamarin.Forms" Version="3.6.0.264807" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All"/>    
   </ItemGroup>
   <ItemGroup>

--- a/Reloader/Xamarin.Forms.HotReload.Reloader/Xamarin.Forms.HotReload.Reloader.csproj
+++ b/Reloader/Xamarin.Forms.HotReload.Reloader/Xamarin.Forms.HotReload.Reloader.csproj
@@ -2,10 +2,22 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+     
+    <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+      
+    <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!-- Optional: Include the PDB in the built .nupkg -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="3.6.0.220655" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All"/>    
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="MainPage.xaml.cs" />


### PR DESCRIPTION
source link allows you to debug your lib without cloning the repository and reference the locally build dll.