### PR TITLE
[Extension] Send content and path of updated file to reloaders / listeners

### DIFF
--- a/Extension/Xamarin.Forms.HotReload.Extension/ExtensionCore.cs
+++ b/Extension/Xamarin.Forms.HotReload.Extension/ExtensionCore.cs
@@ -14,11 +14,15 @@ namespace Xamarin.Forms.HotReload.Extension
 {
     internal class ExtensionCore
     {
+        private const string XamlResourceExtension = ".xaml";
+        private const string CssResourceExtension = ".css";
+
         private readonly IGuiService _guiService;
         private readonly ISettingsService _settingsService;
         private readonly ILogger _logger;
         private readonly JsonSerializer _serializer;
         private readonly HotReloadClientsHolder _clientsHolder;
+        private readonly HashSet<string> _supportedResourceExtensions;
 
         private IEnvironmentCommand _enableExtensionCommand;
         private IEnvironmentCommand _disableExtensionCommand;
@@ -31,6 +35,11 @@ namespace Xamarin.Forms.HotReload.Extension
             _settingsService = settingsStore;
             _logger = logger;
             _clientsHolder = new HotReloadClientsHolder();
+            _supportedResourceExtensions = new HashSet<string>
+            {
+                XamlResourceExtension,
+                CssResourceExtension
+            };
         }
 
         internal void Init(EnvironmentService environmentService,
@@ -167,21 +176,9 @@ namespace Xamarin.Forms.HotReload.Extension
 
             try
             {
-                if (documentExtension != null)
+                if (_supportedResourceExtensions.Contains(documentExtension.ToLowerInvariant()))
                 {
-                    switch (documentExtension.ToLowerInvariant())
-                    {
-                        case ".xaml":
-                        {
-                            await _clientsHolder.UpdateXamlAsync(e.Content);
-                            break;
-                        }
-                        case ".css":
-                        {
-                            await _clientsHolder.UpdateCssAsync(e.Path);
-                            break;
-                        }
-                    }
+                    await _clientsHolder.UpdateResourceAsync(e.Path, e.Content);
                 }
             }
             catch (AggregateException)

--- a/Extension/Xamarin.Forms.HotReload.Extension/Helpers/HotReloadClientsHolder.cs
+++ b/Extension/Xamarin.Forms.HotReload.Extension/Helpers/HotReloadClientsHolder.cs
@@ -21,27 +21,14 @@ namespace Xamarin.Forms.HotReload.Extension.Helpers
             }
         }
 
-        internal Task UpdateXamlAsync(string contentString)
+        internal Task UpdateResourceAsync(string pathString, string contentString)
         {
             var establishConnectionTasks = new Task[_hotReloadClients.Count];
 
             for (int i = 0; i < _hotReloadClients.Count; i++)
             {
                 var connectionItem = _hotReloadClients.ElementAt(i);
-                establishConnectionTasks[i] = connectionItem.Value.PostXamlUpdateAsync(contentString);
-            }
-
-            return Task.Run(() => Task.WaitAll(establishConnectionTasks));
-        }
-
-        internal Task UpdateCssAsync(string pathToCssFile)
-        {
-            var establishConnectionTasks = new Task[_hotReloadClients.Count];
-
-            for (int i = 0; i < _hotReloadClients.Count; i++)
-            {
-                var connectionItem = _hotReloadClients.ElementAt(i);
-                establishConnectionTasks[i] = connectionItem.Value.PostCssUpdateAsync(pathToCssFile);
+                establishConnectionTasks[i] = connectionItem.Value.PostResourceUpdateAsync(pathString, contentString);
             }
 
             return Task.Run(() => Task.WaitAll(establishConnectionTasks));

--- a/Extension/Xamarin.Forms.HotReload.Extension/HotReloadClient.cs
+++ b/Extension/Xamarin.Forms.HotReload.Extension/HotReloadClient.cs
@@ -24,17 +24,12 @@ namespace Xamarin.Forms.HotReload.Extension
             }
         }
 
-        internal async Task PostXamlUpdateAsync(string xmlString)
+        internal async Task PostResourceUpdateAsync(string pathString, string contentString)
         {
-            var data = Encoding.UTF8.GetBytes(xmlString);
+            var escapedFilePath = Uri.EscapeDataString(pathString);
+            var data = Encoding.UTF8.GetBytes(contentString);
             var content = new ByteArrayContent(data);
-            await _httpClient.PostAsync("reload", content);
-        }
-
-        internal async Task PostCssUpdateAsync(string pathToCssFile)
-        {
-            var escapedCssFilePath = Uri.EscapeUriString(pathToCssFile);
-            await _httpClient.PostAsync($"/reload/css?path={escapedCssFilePath}", null);
+            await _httpClient.PostAsync($"/reload?path={escapedFilePath}", content);
         }
     }
 }

--- a/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
+++ b/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.HotReload.Observer
 {
     public static class FileObserver
     {
-        private static readonly string[] _supportedFileExtensions = { ".xaml" };
+        private static readonly string[] _supportedFileExtensions = { ".xaml", ".css" };
         private static readonly object _locker = new object();
         private static HttpClient _client;
         private static DateTime _lastChangeTime;
@@ -125,11 +125,12 @@ namespace Xamarin.Forms.HotReload.Observer
         {
             try
             {
+                var escapedFilePath = Uri.EscapeDataString(filePath);
                 var xaml = File.ReadAllText(filePath);
                 var data = Encoding.UTF8.GetBytes(xaml);
                 using (var content = new ByteArrayContent(data))
                 {
-                    var sendTasks = _addresses.Select(addr => _client.PostAsync($"{addr}/reload", content)).ToArray();
+                    var sendTasks = _addresses.Select(addr => _client.PostAsync($"{addr}/reload?path={escapedFilePath}", content)).ToArray();
 
                     await Task.WhenAll(sendTasks).ConfigureAwait(false);
                 }


### PR DESCRIPTION
Fixed css files observing.

So, we will send content and path of updated file always

RE: https://github.com/AndreiMisiukevich/HotReload/issues/24