### PR TITLE
Fix RetrieveClassName Regex

### DIFF
--- a/Reloader/Xamarin.Forms.HotReload.Reloader/HotReloader.cs
+++ b/Reloader/Xamarin.Forms.HotReload.Reloader/HotReloader.cs
@@ -541,7 +541,7 @@ namespace Xamarin.Forms
         }
 
         private string RetrieveClassName(string xaml)
-            => Regex.Match(xaml ?? string.Empty, "x:Class=\"(.+)\"").Groups[1].Value;
+            => Regex.Match(xaml ?? string.Empty, "x:Class=\"([^\"]+)\"").Groups[1].Value;
 
         private string RetrieveClassName(Type type)
             => type.FullName;

--- a/Reloader/Xamarin.Forms.HotReload.Reloader/HotReloader.cs
+++ b/Reloader/Xamarin.Forms.HotReload.Reloader/HotReloader.cs
@@ -541,7 +541,7 @@ namespace Xamarin.Forms
         }
 
         private string RetrieveClassName(string xaml)
-            => Regex.Match(xaml ?? string.Empty, "x:Class=\"([^\"]+)\"").Groups[1].Value;
+            => Regex.Match(xaml ?? string.Empty, "x:Class[\n\r[:space:]]*=[\n\r[:space:]]*\"([^\"]+)\"").Groups[1].Value;
 
         private string RetrieveClassName(Type type)
             => type.FullName;


### PR DESCRIPTION
RetrieveClassName Regex doesn't stop for the enclosing double quote if additional attributes follows:

![image](https://user-images.githubusercontent.com/1769090/56953884-c55e9d00-6b3d-11e9-96d3-791e3347cc8c.png)

If you change to `.` to `[^\"]` it will fix the issue:

![image](https://user-images.githubusercontent.com/1769090/56953933-deffe480-6b3d-11e9-9918-f8b8e343d142.png)