### PR TITLE
Show 'Address is Detected' message only when it is a new address

### DIFF
--- a/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
+++ b/Observer/Xamarin.Forms.HotReload.Observer/FileObserver.cs
@@ -9,7 +9,6 @@ using System.Security.Permissions;
 using System.Text;
 using System.Threading.Tasks;
 using static System.Math;
-using System.Net;
 using System.Threading;
 
 namespace Xamarin.Forms.HotReload.Observer
@@ -75,8 +74,11 @@ namespace Xamarin.Forms.HotReload.Observer
                     var address = addressMsg.Split(';').FirstOrDefault();
                     if (address != null)
                     {
-                        Console.WriteLine($"ADDRESS IS DETECTED: {address}");
-                        _addresses.Add(address);
+                        if (!_addresses.Contains(address))
+                        {
+                            Console.WriteLine($"ADDRESS IS DETECTED: {address}");
+                            _addresses.Add(address);
+                        }
                     }
                 };
                 receiver.StartAsync();


### PR DESCRIPTION
Using the observer is too verbose with this change. This decreases the amount of logging messages shown when a new device is connected.