### PR TITLE
Remove x:Name attributes when reloading to avoid Xaml parse errors on Xamarin Forms 4.2

### DIFF
--- a/Reloader/Xamarin.Forms.HotReload.Reloader/HotReloader.cs
+++ b/Reloader/Xamarin.Forms.HotReload.Reloader/HotReloader.cs
@@ -40,6 +40,7 @@ namespace Xamarin.Forms
         Type XamlLoaderType => _xamlLoaderType ?? (_xamlLoaderType = Assembly.Load("Xamarin.Forms.Xaml").GetType("Xamarin.Forms.Xaml.XamlLoader"));
 
         private HashSet<string> _cellViewReloadProps = new HashSet<string> { "Orientation", "Spacing", "IsClippedToBounds", "Padding", "HorizontalOptions", "Margin", "VerticalOptions", "Visual", "FlowDirection", "AnchorX", "AnchorY", "BackgroundColor", "HeightRequest", "InputTransparent", "IsEnabled", "IsVisible", "MinimumHeightRequest", "MinimumWidthRequest", "Opacity", "Rotation", "RotationX", "RotationY", "Scale", "ScaleX", "ScaleY", "Style", "TabIndex", "IsTabStop", "StyleClass", "TranslationX", "TranslationY", "WidthRequest", "DisableLayout", "Resources", "AutomationId", "ClassId", "StyleId" };
+        private const string _nameRegexPattern = @"\s+x:[Nn]ame=""\w+""";
 
         internal Application App { get; private set; }
 
@@ -137,6 +138,7 @@ namespace Xamarin.Forms
                     loadXaml.Invoke(null, new object[] { obj, xaml, true });
                     return;
                 }
+                xaml = Regex.Replace(xaml, _nameRegexPattern, "", RegexOptions.Compiled);
                 obj.LoadFromXaml(xaml);
             };
 

--- a/Sample/Xamarin.Forms.HotReload.Sample/Pages/ItemsPage.xaml
+++ b/Sample/Xamarin.Forms.HotReload.Sample/Pages/ItemsPage.xaml
@@ -8,7 +8,8 @@
              xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             x:Class="Xamarin.Forms.HotReload.Sample.Pages.ItemsPage">
+             x:Class="Xamarin.Forms.HotReload.Sample.Pages.ItemsPage"
+             x:Name="page">
     
     <ContentPage.Resources> 
         <StyleSheet>
@@ -39,7 +40,8 @@
                 HorizontalTextAlignment="Center"
                 HorizontalOptions="FillAndExpand"
                 BackgroundColor="{StaticResource TestButtonBackColor}"
-                StyleClass="TestButtonStyle">
+                StyleClass="TestButtonStyle"
+                x:Name="label">
             <Label.GestureRecognizers>
                 <TapGestureRecognizer Tapped="OnCodePageTapped" />
             </Label.GestureRecognizers>
@@ -48,6 +50,7 @@
             SelectionMode="None"
             VerticalOptions="FillAndExpand"
             ItemTapped="OnItemTapped"
+            x:Name="listView"
             RowHeight="180"
             BackgroundColor="{StaticResource ListBgColor}"
             ItemsSource="{Binding Items}">

--- a/Sample/Xamarin.Forms.HotReload.Sample/Pages/ItemsPage.xaml
+++ b/Sample/Xamarin.Forms.HotReload.Sample/Pages/ItemsPage.xaml
@@ -45,6 +45,15 @@
             <Label.GestureRecognizers>
                 <TapGestureRecognizer Tapped="OnCodePageTapped" />
             </Label.GestureRecognizers>
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal">
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor" Value="Lime" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
         </Label>
         <ListView
             SelectionMode="None"


### PR DESCRIPTION
Fixes #119, related to https://github.com/xamarin/Xamarin.Forms/issues/7685

Do you see any problems with this approach? From what I understand the namescope is based on the `x:Name` declared in the element.

~Known issues: VisualStates that are using `x:Name` instead of `Name` won't reload. A workaround is to simply start using `Name` for `VisualStateGroup` and `VisualState`, as they [are compatible](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/visual-state-manager).~ Fixed in the new push.

In this new approach I'm working on, I loop through every children of the XAML to remove `x:Name` from everyone except `VisualStateGroup` and `VisualState`. What do you think? Could this be a problem? (maybe performance?)